### PR TITLE
Add Merge API operation for Contact resource

### DIFF
--- a/intercom/api_operations/merge.py
+++ b/intercom/api_operations/merge.py
@@ -1,0 +1,12 @@
+class Merge(object):
+    """A mixin that provides `merge` functionality."""
+
+    def merge(self, from_lead, into_user):
+        """Merge the specified contact lead into the specified contact user."""
+        self.client.post(
+            '/contacts/merge',
+            {
+                'from': from_lead.id,
+                'into': into_user.id,
+            }
+        )

--- a/intercom/service/contact.py
+++ b/intercom/service/contact.py
@@ -9,11 +9,12 @@ from intercom.api_operations.search import Search
 from intercom.api_operations.delete import Delete
 from intercom.api_operations.save import Save
 from intercom.api_operations.load import Load
+from intercom.api_operations.merge import Merge
 from intercom.extended_api_operations.tags import Tags
 from intercom.service.base_service import BaseService
 
 
-class Contact(BaseService, All, Find, FindAll, Delete, Save, Load, Submit, Tags, Search):
+class Contact(BaseService, All, Find, FindAll, Delete, Save, Load, Submit, Tags, Search, Merge):
 
     @property
     def collection_class(self):


### PR DESCRIPTION
Adds the API operation merge to Contact resources.

API reference: https://developers.intercom.com/intercom-api-reference/reference#merge-contact

As `from` is a reserved keyword in Python, the `merge()` signature is `from_lead` and `into_user`, where both references are a Contact resources having role set to "lead" and "user" respectively.